### PR TITLE
修复throttle闭包导致的内存泄漏问题

### DIFF
--- a/func/throttle.js
+++ b/func/throttle.js
@@ -7,21 +7,20 @@
   * @return {Function}
   */
 function throttle (callback, wait, options) {
-  var args, context
   var opts = options || {}
   var runFlag = false
   var timeout = 0
   var optLeading = 'leading' in opts ? opts.leading : true
   var optTrailing = 'trailing' in opts ? opts.trailing : false
-  var runFn = function () {
+  var runFn = function (args, context) {
     runFlag = true
     callback.apply(context, args)
     timeout = setTimeout(endFn, wait)
   }
-  var endFn = function () {
+  var endFn = function (args, context) {
     timeout = 0
     if (!runFlag && optTrailing === true) {
-      runFn()
+      runFn(args, context)
     }
   }
   var cancelFn = function () {
@@ -37,9 +36,9 @@ function throttle (callback, wait, options) {
     runFlag = false
     if (timeout === 0) {
       if (optLeading === true) {
-        runFn()
+        runFn(args, context)
       } else if (optTrailing === true) {
-        timeout = setTimeout(endFn, wait)
+        timeout = setTimeout(() => endFn(args, context), wait)
       }
     }
   }

--- a/func/throttle.js
+++ b/func/throttle.js
@@ -31,8 +31,8 @@ function throttle (callback, wait, options) {
     return rest
   }
   var throttled = function () {
-    args = arguments
-    context = this
+    const args = arguments
+    const context = this
     runFlag = false
     if (timeout === 0) {
       if (optLeading === true) {


### PR DESCRIPTION
此throttle函数存储了最后一次触发事件时的参数arguments和context，导致如果后续不再触发此事件，那么上一次触发事件时的dom以及组件都无法被内存回收。

比如在vxe-table中，触发mouse-wheel后表格会被缓存，后面即使销毁了表格，其内存也无法被释放。当然因为mouse-wheel事件是注册在window上的，在空白区域再次滚动鼠标滚轮，内存就会得以释放，但是新的内容又会被缓存，再关闭另一个表格或者其他组件，内存同样无法被回收。

![image](https://user-images.githubusercontent.com/18558054/176632777-3a84e569-6dc3-46bc-917e-6a38a44f0984.png)

![image](https://user-images.githubusercontent.com/18558054/176623321-cb9c98ef-39df-4e02-bee2-62f77f231076.png)

![image](https://user-images.githubusercontent.com/18558054/176624350-36877e73-433f-4c1e-809e-f3adccac8553.png)
