### PR TITLE
fix:clone Object.create(null)

### DIFF
--- a/func/clone.js
+++ b/func/clone.js
@@ -16,7 +16,7 @@ function copyValue (val, isDeep) {
   if (val) {
     switch(objectToString.call(val)) {
       case "[object Object]": {
-        var restObj = Object.create(val.__proto__)
+        var restObj = Object.create(Object.getPrototypeOf(val))
         objectEach(val, function (item, key) {
           restObj[key] = handleValueClone(item, isDeep)
         })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -2492,6 +2492,9 @@ describe('Base functions', () => {
     expect(
       XEUtils.clone([['11', /\d/], [[11, [[new Date()], 22, [{ aa: 33 }, 44]]], { jj: 99 }], { uu: 88 }])
     ).toEqual([['11', /\d/], [[11, [[new Date()], 22, [{ aa: 33 }, 44]]], { jj: 99 }], { uu: 88 }])
+    expect(
+      XEUtils.clone(Object.create(null))
+    ).toEqual(Object.create(null))
 
     let v1 = {
       num: 11,


### PR DESCRIPTION
Fix: 
  deep clone a object that created by Object.create(null) will report a error
