### PR TITLE
perf 优化toArrayTree函数性能

### DIFF
--- a/func/toArrayTree.js
+++ b/func/toArrayTree.js
@@ -37,7 +37,8 @@ function toArrayTree (array, options) {
   var optData = opts.data
   var result = []
   var treeMap = {}
-  var idList, id, treeData, parentId
+  var idsMap = {}
+  var id, treeData, parentId
 
   if (optSortKey) {
     array = orderBy(clone(array), optSortKey)
@@ -46,8 +47,9 @@ function toArrayTree (array, options) {
     }
   }
 
-  idList = map(array, function (item) {
-    return item[optKey]
+  each(array, function (item) {
+    id = item[optKey]
+    idsMap[id] = true
   })
 
   each(array, function (item) {
@@ -72,7 +74,7 @@ function toArrayTree (array, options) {
     }
 
     if (!optStrict || (optStrict && !parentId)) {
-      if (!includes(idList, parentId)) {
+      if (!idsMap[parentId]) {
         result.push(treeData)
       }
     }


### PR DESCRIPTION
vxe-table 中使用树形虚拟列表，在大数据量下会存在严重的性能问题

1.6w 条数据的树形虚拟列表
![20220929-160524](https://user-images.githubusercontent.com/15241403/192976223-ba1e8482-ab2b-474e-b507-e505d6e8bfbf.jpg)

优化后
![20220929-160943](https://user-images.githubusercontent.com/15241403/192976985-8d13a286-ebc8-4325-9ee6-bdd87f1cfd98.jpg)


