### PR TITLE
Update clone.js

### DIFF
--- a/func/clone.js
+++ b/func/clone.js
@@ -44,7 +44,7 @@ function copyValue (val, isDeep) {
       case "[object Map]": {
         var restMap = getCativeCtor(val)
         restMap.forEach(function (item, key) {
-          restMap.set(handleValueClone(item, isDeep))
+          restMap.set(key, handleValueClone(item, isDeep))
         })
         return restMap
       }


### PR DESCRIPTION
Map 在 forEach 的时候，参数分别为：值，键，对象
因此 set 的时候需要将键也设置进去

```
case "[object Map]": {
        var restMap = getCativeCtor(val)
        restMap.forEach(function (item, key) {
          restMap.set(handleValueClone(item, isDeep))
        })
        return restMap
      }
```

应该为： ```restMap.set(key, handleValueClone(item, isDeep))```